### PR TITLE
adds new clusterInvisibleViews property to OCMapView

### DIFF
--- a/OCMapView/OCMapView.h
+++ b/OCMapView/OCMapView.h
@@ -108,6 +108,11 @@ default: 0.2*/
  default: 0.0 (no min. zoom)*/
 @property(nonatomic, assign) CLLocationDegrees minLongitudeDeltaToCluster;
 
+//
+/// Clusters all annotations, even if they are outside of the visible MKCoordinateRegion
+/* default: NO (checks for boundaries)*/
+@property BOOL clusterInvisibleViews;
+
 // ======================================
 // Clustering
 


### PR DESCRIPTION
with `clusterInvisibleViews` set to `YES`, you need to call `-doClustering` only on zoom level changes, not on every other scrolling action. Performs quite good, tested with ~1000 annotations on 50,000 km^2.
