### PR TITLE
Added check for title and subtitle because they are optional

### DIFF
--- a/OCMapView/OCAnnotation.m
+++ b/OCMapView/OCAnnotation.m
@@ -29,8 +29,12 @@
         _coordinate = [annotation coordinate];
         [_annotationsInCluster addObject:annotation];
         
-        self.title = annotation.self.title;
-        self.subtitle = annotation.self.title;
+        if ([annotation respondsToSelector:@selector(title)]) {
+            self.title = [annotation title];
+        }
+        if ([annotation respondsToSelector:@selector(subtitle)]) {
+            self.subtitle = [annotation subtitle];
+        }
     }
     
     return self;


### PR DESCRIPTION
Added check for title and subtitle because they are optional thus may be not implemented.

This will prevent a crash if a id<MKAnnotation> doesn't implement title or subtitle properties.
Also replaced title with subtitle in the self.subtitle assignment line.
