### PR TITLE
Improving performance by removing dynamicism of the coordinate property

### DIFF
--- a/OCMapView/OCAlgorithms.m
+++ b/OCMapView/OCAlgorithms.m
@@ -24,9 +24,10 @@
     {
 		// Find fitting existing cluster
 		BOOL foundCluster = NO;
+        CLLocationCoordinate2D annotationCoordinate = [annotation coordinate];
         for (OCAnnotation *clusterAnnotation in clusteredAnnotations) {
             // If the annotation is in range of the cluster, add it
-            if ((CLLocationCoordinateDistance([annotation coordinate], [clusterAnnotation coordinate]) <= radius)) {
+            if ((CLLocationCoordinateDistance(annotationCoordinate, [clusterAnnotation coordinate]) <= radius)) {
                 // check group
                 if (grouped && [annotation conformsToProtocol:@protocol(OCGrouping)]) {
                     if (![clusterAnnotation.groupTag isEqualToString:((id <OCGrouping>)annotation).groupTag])


### PR DESCRIPTION
See for my motivations my comment on commit: https://github.com/yinkou/OCMapView/commit/99438367ee00075b981be47d4d2103a5d39fc56b

To test the improvement: use the sample application in the simulator. hit "add 100 annotations" many times. After 1000 or so additions it gets slower, at around 5000 it takes seconds. Also, at 5000 annotations, grouping/ungrouping the clusters takes 4-5 seconds on my machine.

With this pull requests, adding 100 annotations has no noticeable slow down, and grouping/ungrouping clusters at 5000 annotates are nearly instantaneous
