### PR TITLE
Improved Minimun Zoom implementation strategy

### DIFF
--- a/OCMapView/OCMapView.h
+++ b/OCMapView/OCMapView.h
@@ -6,6 +6,7 @@
 //
 
 #import <MapKit/MapKit.h>
+#import <AvailabilityMacros.h>
 
 #import "OCDistance.h"
 #import "OCAnnotation.h"
@@ -52,10 +53,16 @@ default: 0.2*/
 @property(nonatomic, assign) BOOL clusterByGroupTag;
 
 //
-/// Defines the "zoom" from where the map should start clustering.
+/// Defines the "zoom" from where the map should start clustering, referenced by Longitude.
 /** If the map is zoomed below this value it won't cluster.
  default: 0.0 (no min. zoom)*/
-@property(nonatomic, assign) CLLocationDegrees minLongitudeDeltaToCluster;
+@property(nonatomic, assign) CLLocationDegrees minLongitudeDeltaToCluster DEPRECATED_MSG_ATTRIBUTE("Use minLatitudeDeltaToCluster instead.");
+
+//
+/// Defines the "zoom" from where the map should start clustering, referenced by Latitude.
+/** If the map is zoomed below this value it won't cluster.
+ default: 0.0 (no min. zoom)*/
+@property(nonatomic, assign) CLLocationDegrees minLatitudeDeltaToCluster;
 
 //
 /// Defines how many annotations are needed to build a cluster

--- a/OCMapView/OCMapView.m
+++ b/OCMapView/OCMapView.m
@@ -47,6 +47,7 @@
     _clusteringMethod = OCClusteringMethodBubble;
     _clusterSize = 0.2;
     _minLongitudeDeltaToCluster = 0.0;
+    _minLatitudeDeltaToCluster = 0.0;
     _minimumAnnotationCountPerCluster = 0;
     _clusteringEnabled = YES;
     _clusterByGroupTag = NO;
@@ -59,6 +60,7 @@
                                      @"clusterSize",
                                      @"clusterByGroupTag",
                                      @"minLongitudeDeltaToCluster",
+                                     @"minLatitudeDeltaToCluster",
                                      @"minimumAnnotationCountPerCluster",
                                      @"clusterInvisibleViews",
                                      @"annotationsToIgnore"];
@@ -168,7 +170,7 @@
     
     // Cluster annotations, when enabled and map is above the minimum zoom
     NSArray *clusteredAnnotations;
-    if (_clusteringEnabled && (self_region.span.longitudeDelta > _minLongitudeDeltaToCluster))
+    if (_clusteringEnabled && (self_region.span.longitudeDelta > _minLongitudeDeltaToCluster) && (self_region.span.latitudeDelta > _minLatitudeDeltaToCluster) )
     {
         //calculate cluster radius
         CLLocationDistance clusterRadius = self_region.span.longitudeDelta * _clusterSize;


### PR DESCRIPTION
-Before, the minimum Zoom level to perform clustering was defined by the property 'minLongitudeDeltaToCluster'. The problem With this approach is that the equivalent value for 1 degree of Longitude values vary (according to latitude values) from 0 meters in the poles, to 111319.46 meters in the equator. This means that if we set:

``` objective-c
minLongitudeDeltaToCluster = 1.0
```

If the latitude is 90 or -90, it will ALWAYS perform clustering, and if the latitude is 0, it will perform clustering when we zoom out the equivalent to 111 Kilometers.

On the other hand, Latitude distances does not vary in such a big way, and are therefore a better way to reference the current level of zoom.

-Based on this principle, I've added the property

``` objective-c
@property(nonatomic, assign) CLLocationDegrees minLatitudeDeltaToCluster;
```

The ideal thing would be to completely remove the minLongitudeDeltaToCluster property, but considering compatibility issues, it's been Deprecated:

``` objective-c
@property(nonatomic, assign) CLLocationDegrees minLongitudeDeltaToCluster DEPRECATED_MSG_ATTRIBUTE("Use minLatitudeDeltaToCluster instead.");
```

Right Now the algorithm considers BOTH parameters when evaluating the zoom level, but on the next release it should only use the minLatitudeDeltaToCluster value.

I hope it was helpful =)
